### PR TITLE
Fix CI pipeline by adding permissions for id-token to write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   plugin-ci:


### PR DESCRIPTION
# Closes #<!-- GitHub issue number that this pull request closes. Pull requests without a reference to a GitHub issue may be closed. -->

## Description
Fix CI pipeline by adding permissions for id-token to write

## Ticket
https://mattermost.atlassian.net/browse/CLD-9264
