### PR TITLE
Update translation prompts and config help text

### DIFF
--- a/server/handle_messages.go
+++ b/server/handle_messages.go
@@ -90,12 +90,12 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 	for _, language := range strings.Split(languages, ",") {
 		waitlist <- struct{}{}
 		waitGroup.Add(1)
-		go func(lang string) {
+		go func(langCode string) {
 			defer waitGroup.Done()
 			maxRetry := 10
 
 			for {
-				result, err := p.translateText(post.Message, post.UserId, lang)
+				result, err := p.translateText(post.Message, post.UserId, langCode)
 				if err != nil {
 					maxRetry--
 					if maxRetry == 0 {
@@ -105,7 +105,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 				}
 
 				mutex.Lock()
-				translations[lang] = result
+				translations[langCode] = result
 				// Store translations in post props
 				if post.Props == nil {
 					post.Props = make(model.StringInterface)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -53,6 +53,38 @@ func (p *Plugin) isChannelTranslationEnabled(channelID string) (bool, error) {
 	return enabled, nil
 }
 
+func (p *Plugin) getLanguageName(langCode string) string {
+	languageMap := map[string]string{
+		"bg":    "Bulgarian",
+		"de":    "German",
+		"en":    "English",
+		"en-AU": "English (Australia)",
+		"es":    "Spanish",
+		"fa":    "Persian",
+		"fr":    "French",
+		"hu":    "Hungarian",
+		"it":    "Italian",
+		"ja":    "Japanese",
+		"ko":    "Korean",
+		"nl":    "Dutch",
+		"pl":    "Polish",
+		"pt-BR": "Portuguese (Brazil)",
+		"ro":    "Romanian",
+		"ru":    "Russian",
+		"sv":    "Swedish",
+		"tr":    "Turkish",
+		"uk":    "Ukrainian",
+		"vi":    "Vietnamese",
+		"zh-CN": "Chinese (Simplified)",
+		"zh-TW": "Chinese (Traditional)",
+	}
+
+	if name, exists := languageMap[langCode]; exists {
+		return name
+	}
+	return langCode
+}
+
 func (p *Plugin) OnActivate() error {
 	p.pluginAPI = pluginapi.NewClient(p.API, p.Driver)
 	p.licenseChecker = enterprise.NewLicenseChecker(p.pluginAPI)
@@ -62,12 +94,12 @@ func (p *Plugin) OnActivate() error {
 	return nil
 }
 
-func (p *Plugin) translateText(message, requestorID, lang string) (string, error) {
+func (p *Plugin) translateText(message, requestorID, langCode string) (string, error) {
 	client := interpluginclient.NewClient(&p.MattermostPlugin)
 
 	promptParameters := map[string]any{
 		"Message":  message,
-		"Language": lang,
+		"Language": p.getLanguageName(langCode),
 	}
 	request := interpluginclient.SimpleCompletionRequest{
 		SystemPrompt:    translationSystemPrompt,

--- a/server/prompts.go
+++ b/server/prompts.go
@@ -4,13 +4,10 @@
 package main
 
 const translationSystemPrompt = `
-You are a translation expert. Translate the given text to the requested languages.
+Translate the given text to the requested language.
 
 You consider the text to translate the one contained between <text-to-translate></text-to-translate> tag.
-
-You always provide the most accurate and literal translation possible.
-
-You always provide the translations for all the lines in the translatable text.
+You always provide the most accurate translation possible.
 
 You don't change the emojis text from their original form, for example, :heart_eyes: should be kept as :heart_eyes:.
 
@@ -20,28 +17,13 @@ Take into account that we are translating messages inside Mattermost, so they ar
 
 You should always preserve the original text of the hashtags, channel mentions, and user mentions, also be sure that you put spaces between the hashtags and the other text.
 
-Do not include any other text or explanation.
+Do not include any other text or explanation in your response, just the translated text. If the text is already in the requested language, simply return the original text without any changes and no other comments.
+IT IS VERY IMPORTANT THAT YOU DO NOT ADD ANY OTHER TEXT OR EXPLANATION, JUST THE TRANSLATED TEXT.
 
-{{if .RequestingUser.Locale}}
-The message creator locale is '{{.RequestingUser.Locale}}', if you doubt about the meaning of a word, you can use it to help you.
-{{end}}
-
-For example, the text:
-<text-to-translate>
-Noted, @jespino . So no "on the fly" server reload is implemented ? :heart_eyes:
-
-This is a question, not a criticism, especially as the binary runs on an Alpine container, so no systemd
-</text-to-translate>
-
-should be translated to:
-
-Anotado, @jespino . Así que no esta implementada la recarga del servidor \"al vuelo\"? :heart_eyes:
-
-Esto es una pregunta, no una crítica, especialmente porque el binario se ejecuta en un contenedor Alpine, por lo que no hay systemd`
+You are to translate into {{.Parameters.Language}}. Remember if the text is aready in {{.Parameters.Language}}, you should return the original text without any changes.
+`
 
 const translationUserPrompt = `
 <text-to-translate>
 {{.Parameters.Message}}
-</text-to-translate>
-
-Target language: {{.Parameters.Language}}`
+</text-to-translate>`

--- a/server/prompts.go
+++ b/server/prompts.go
@@ -20,7 +20,7 @@ You should always preserve the original text of the hashtags, channel mentions, 
 Do not include any other text or explanation in your response, just the translated text. If the text is already in the requested language, simply return the original text without any changes and no other comments.
 IT IS VERY IMPORTANT THAT YOU DO NOT ADD ANY OTHER TEXT OR EXPLANATION, JUST THE TRANSLATED TEXT.
 
-You are to translate into {{.Parameters.Language}}. Remember if the text is aready in {{.Parameters.Language}}, you should return the original text without any changes.
+You are to translate into {{.Parameters.Language}}. Remember if the text is already in {{.Parameters.Language}}, you should return the original text without any changes.
 `
 
 const translationUserPrompt = `

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -101,7 +101,7 @@ const Config = (props: Props) => {
                         label={intl.formatMessage({defaultMessage: 'Translation Languages'})}
                         value={value.translationLanguages}
                         onChange={(e) => props.onChange(props.id, {...value, translationLanguages: e.target.value})}
-                        helpText={intl.formatMessage({defaultMessage: 'Comma-separated list of language codes to translate messages to (e.g. "en,es,fr"). Default is "en".'})}
+                        helpText={intl.formatMessage({defaultMessage: 'Comma-separated list of language codes to translate messages to (e.g. "English,Spanish,French").'})}
                     />
                     <TextItem
                         label={intl.formatMessage({defaultMessage: 'Translation Bot'})}

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -101,7 +101,7 @@ const Config = (props: Props) => {
                         label={intl.formatMessage({defaultMessage: 'Translation Languages'})}
                         value={value.translationLanguages}
                         onChange={(e) => props.onChange(props.id, {...value, translationLanguages: e.target.value})}
-                        helpText={intl.formatMessage({defaultMessage: 'Comma-separated list of language codes to translate messages to (e.g. "English,Spanish,French").'})}
+                        helpText={intl.formatMessage({defaultMessage: 'Comma-separated list of language codes to translate messages to (e.g. "en,es,fr"). Default is "en".'})}
                     />
                     <TextItem
                         label={intl.formatMessage({defaultMessage: 'Translation Bot'})}

--- a/webapp/src/components/translated_post.tsx
+++ b/webapp/src/components/translated_post.tsx
@@ -36,7 +36,7 @@ export const TranslatedPost = (props: Props) => {
     }
 
     const userPreferences = useSelector((state: GlobalState) => state.entities.preferences.myPreferences);
-    const currentUserTranslationPreference = (userPreferences['pp_mattermost-channel-translatio--translation_language'] || {}).value || 'en';
+    const currentUserTranslationPreference = (userPreferences['pp_mattermost-channel-translatio--translation_language'] || {}).value ?? '';
 
     const post = props.post;
     let message = post.message;

--- a/webapp/src/components/user_settings/translation_language.tsx
+++ b/webapp/src/components/user_settings/translation_language.tsx
@@ -16,7 +16,7 @@ const TranslationLanguageSetting = ({informChange}: Props) => {
     const [languages, setLanguages] = useState<string[]>([]);
     const [selectedLanguage, setSelectedLanguage] = useState<string>('');
     const userPreferences = useSelector((state: any) => state.entities.preferences.myPreferences);
-    const currentUserTranslationPreference = (userPreferences['pp_mattermost-channel-translatio--translation_language'] || {}).value || 'en';
+    const currentUserTranslationPreference = (userPreferences['pp_mattermost-channel-translatio--translation_language'] || {}).value ?? '';
 
     useEffect(() => {
         setSelectedLanguage(currentUserTranslationPreference);


### PR DESCRIPTION
Simplified translation prompts and updated help text for better clarity.

These are just tweaks to get it to work for a demo. More substantial modifications are required for reliable use. 